### PR TITLE
Use 10px padding for page bottom, and min-height for short pages

### DIFF
--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -5,11 +5,11 @@
 
   .appContainer{
     width: 100%;
-    padding: 0px;
+    padding: 0 0 10px 0;
     margin: 0px;
     max-width: 100%;
     background-image: url('Christmas.jpg');
-    height: 5000px
+    min-height: 100vh;
   }
 }
 


### PR DESCRIPTION
A little fix for the page height, to avoid pages having a large gap at the bottom, but still have a full background on shorter pages